### PR TITLE
Fixup/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ bgg-api gem [![Build Status](https://travis-ci.org/bhardin/bgg-api.png?branch=ma
 A [boardgamegeek](http://boardgamegeek.com) Ruby wrapper for the [bgg XML Version 2 API](http://boardgamegeek.com/wiki/page/BGG_XML_API2).
 
 ## Installing the Gem
-Do the following to install the  [bgg-api gem](http://rubygems.org/gems/bgg-api) Ruby Gem. 
+Do the following to install the  [bgg-api gem](http://rubygems.org/gems/bgg-api) Ruby Gem.
 
 Add the following to your `Gemfile`:
 
@@ -16,7 +16,7 @@ gem "bgg-api"
 Then run `bundle install` from the command line:
 
     bundle install
-    
+
 ## Using the Gem
 
 Require the gem at the top of any file you want to use.
@@ -30,43 +30,38 @@ or you can use the specialized methods
 
 Create an object and all the xml2 api's documented [here](http://boardgamegeek.com/wiki/page/BGG_XML_API2) should work.
 
-## Search Example
+### Search Example
 
     bgg = BggApi.new
-    bgg.search( {:query => "Burgund", :type => 'boardgame'} )
-    => {"total"=>"2", "termsofuse"=>"http://boardgamegeek.com/xmlapi/termsofuse", "item"=>[{"type"=>"boardgame", "id"=>"5", "name"=>[{"type"=>"primary", "value"=>"Acquire"}]}, {"type"=>"boardgame", "id"=>"37491", "name"=>[{"type"=>"primary", "value"=>"Modern Land Battles (MLB): Target Acquired"}]}]} 
+    bgg.search( {:query => "Acquir", :type => 'boardgame'} )
+    => {"total"=>"2", "termsofuse"=>"http://boardgamegeek.com/xmlapi/termsofuse", "item"=>[{"type"=>"boardgame", "id"=>"5", "name"=>[{"type"=>"primary", "value"=>"Acquire"}], "yearpublished"=>[{"value"=>"1962"}]}, {"type"=>"boardgame", "id"=>"37491", "name"=>[{"type"=>"primary", "value"=>"Modern Land Battles (MLB): Target Acquired"}], "yearpublished"=>[{"value"=>"2010"}]}]}
 
-## Thing Example
+### Thing Example
 
     bgg = BggApi.new
     bgg.thing({:id => "1"})
-    => {"termsofuse"=>"http://boardgamegeek.com/xmlapi/termsofuse", "item"=>[{"type"=>"boardgame", "id"=>"1", "thumbnail"=>["http://cf.geekdo-images.com/images/pic159509_t.jpg"], "image"=>["http://cf.geekdo-images.com/images/pic159509.jpg"], "name"=>[{"type"=>"primary", "sortindex"=>"5", "value"=>"Die Macher"}], "description"=>["Die Macher is a game about seven sequential political races in different regions of Germany. Players are in charge of national political parties, and must manage limited resources to help their party to victory. The winning party will have the most victory points after all the regional elections. There are four different ways of scoring victory points. First, each regional election can supply one to eighty victory points, depending on the size of the region and how well your party does in it. Second, if a party wins a regional election and has some media influence in the region, then the party will receive some media-control victory points. Third, each party has a national party membership which will grow as the game progresses and this will supply a fair number of victory points. Lastly, parties score some victory points if their party platform matches the national opinions at the end of the game.&#10;&#10;The 1986 edition featured 4 parties from the old West Germany and supported 3-4 players. The 1997 edition supports up to 5 players in the re-united Germany and updated several features of the rules as well.  The 2006 edition also supports up to 5 players and adds a shorter 5 round variant and additional rules updates by the original designer.&#10;&#10;Die Macher is #1 in the Valley Games Classic Line&#10;&#10;"], "yearpublished"=>[{"value"=>"1986"}], "minplayers"=>[{"value"=>"3"}], "maxplayers"=>[{"value"=>"5"}], "poll"=>[{"name"=>"suggested_numplayers", "title"=>"User Suggested Number of Players", "totalvotes"=>"104", "results"=>[{"numplayers"=>"1", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"1"}, {"value"=>"Not Recommended", "numvotes"=>"63"}]}, {"numplayers"=>"2", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"1"}, {"value"=>"Not Recommended", "numvotes"=>"64"}]}, {"numplayers"=>"3", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"20"}, {"value"=>"Not Recommended", "numvotes"=>"57"}]}, {"numplayers"=>"4", "result"=>[{"value"=>"Best", "numvotes"=>"18"}, {"value"=>"Recommended", "numvotes"=>"67"}, {"value"=>"Not Recommended", "numvotes"=>"10"}]}, {"numplayers"=>"5", "result"=>[{"value"=>"Best", "numvotes"=>"92"}, {"value"=>"Recommended", "numvotes"=>"9"}, {"value"=>"Not Recommended", "numvotes"=>"0"}]}, {"numplayers"=>"5+", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"0"}, {"value"=>"Not Recommended", "numvotes"=>"43"}]}]}, {"name"=>"suggested_playerage", "title"=>"User Suggested Player Age", "totalvotes"=>"22", "results"=>[{"result"=>[{"value"=>"2", "numvotes"=>"0"}, {"value"=>"3", "numvotes"=>"0"}, {"value"=>"4", "numvotes"=>"0"}, {"value"=>"5", "numvotes"=>"0"}, {"value"=>"6", "numvotes"=>"0"}, {"value"=>"8", "numvotes"=>"0"}, {"value"=>"10", "numvotes"=>"0"}, {"value"=>"12", "numvotes"=>"5"}, {"value"=>"14", "numvotes"=>"10"}, {"value"=>"16", "numvotes"=>"4"}, {"value"=>"18", "numvotes"=>"2"}, {"value"=>"21 and up", "numvotes"=>"1"}]}]}, {"name"=>"language_dependence", "title"=>"Language Dependence", "totalvotes"=>"40", "results"=>[{"result"=>[{"level"=>"1", "value"=>"No necessary in-game text", "numvotes"=>"31"}, {"level"=>"2", "value"=>"Some necessary text - easily memorized or small crib sheet", "numvotes"=>"3"}, {"level"=>"3", "value"=>"Moderate in-game text - needs crib sheet or paste ups", "numvotes"=>"6"}, {"level"=>"4", "value"=>"Extensive use of text - massive conversion needed to be playable", "numvotes"=>"0"}, {"level"=>"5", "value"=>"Unplayable in another language", "numvotes"=>"0"}]}]}], "playingtime"=>[{"value"=>"240"}], "minage"=>[{"value"=>"14"}], "link"=>[{"type"=>"boardgamecategory", "id"=>"1021", "value"=>"Economic"}, {"type"=>"boardgamecategory", "id"=>"1001", "value"=>"Political"}, {"type"=>"boardgamemechanic", "id"=>"2012", "value"=>"Auction/Bidding"}, {"type"=>"boardgamefamily", "id"=>"10643", "value"=>"Country: Germany"}, {"type"=>"boardgamefamily", "id"=>"91", "value"=>"Valley Games Classic Line"}, {"type"=>"boardgamedesigner", "id"=>"1", "value"=>"Karl-Heinz Schmiel"}, {"type"=>"boardgameartist", "id"=>"12517", "value"=>"Marcus Gschwendtner"}, {"type"=>"boardgamepublisher", "id"=>"133", "value"=>"Hans im Glück Verlags-GmbH"}, {"type"=>"boardgamepublisher", "id"=>"2", "value"=>"Moskito"}, {"type"=>"boardgamepublisher", "id"=>"5382", "value"=>"Valley Games, Inc."}]}]}
+     => {"termsofuse"=>"http://boardgamegeek.com/xmlapi/termsofuse", "item"=>[{"type"=>"boardgame", "id"=>"1", "thumbnail"=>["http://cf.geekdo-images.com/images/pic159509_t.jpg"], "image"=>["http://cf.geekdo-images.com/images/pic159509.jpg"], "name"=>[{"type"=>"primary", "sortindex"=>"5", "value"=>"Die Macher"}], "description"=>["Die Macher is a game about seven sequential political races in different regions of Germany. Players are in charge of national political parties, and must manage limited resources to help their party to victory. The winning party will have the most victory points after all the regional elections. There are four different ways of scoring victory points. First, each regional election can supply one to eighty victory points, depending on the size of the region and how well your party does in it. Second, if a party wins a regional election and has some media influence in the region, then the party will receive some media-control victory points. Third, each party has a national party membership which will grow as the game progresses and this will supply a fair number of victory points. Lastly, parties score some victory points if their party platform matches the national opinions at the end of the game.&#10;&#10;The 1986 edition featured 4 parties from the old West Germany and supported 3-4 players. The 1997 edition supports up to 5 players in the re-united Germany and updated several features of the rules as well.  The 2006 edition also supports up to 5 players and adds a shorter 5 round variant and additional rules updates by the original designer.&#10;&#10;Die Macher is #1 in the Valley Games Classic Line&#10;&#10;"], "yearpublished"=>[{"value"=>"1986"}], "minplayers"=>[{"value"=>"3"}], "maxplayers"=>[{"value"=>"5"}], "poll"=>[{"name"=>"suggested_numplayers", "title"=>"User Suggested Number of Players", "totalvotes"=>"111", "results"=>[{"numplayers"=>"1", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"1"}, {"value"=>"Not Recommended", "numvotes"=>"71"}]}, {"numplayers"=>"2", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"1"}, {"value"=>"Not Recommended", "numvotes"=>"71"}]}, {"numplayers"=>"3", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"23"}, {"value"=>"Not Recommended", "numvotes"=>"62"}]}, {"numplayers"=>"4", "result"=>[{"value"=>"Best", "numvotes"=>"21"}, {"value"=>"Recommended", "numvotes"=>"71"}, {"value"=>"Not Recommended", "numvotes"=>"10"}]}, {"numplayers"=>"5", "result"=>[{"value"=>"Best", "numvotes"=>"96"}, {"value"=>"Recommended", "numvotes"=>"10"}, {"value"=>"Not Recommended", "numvotes"=>"2"}]}, {"numplayers"=>"5+", "result"=>[{"value"=>"Best", "numvotes"=>"0"}, {"value"=>"Recommended", "numvotes"=>"0"}, {"value"=>"Not Recommended", "numvotes"=>"50"}]}]}, {"name"=>"suggested_playerage", "title"=>"User Suggested Player Age", "totalvotes"=>"25", "results"=>[{"result"=>[{"value"=>"2", "numvotes"=>"0"}, {"value"=>"3", "numvotes"=>"0"}, {"value"=>"4", "numvotes"=>"0"}, {"value"=>"5", "numvotes"=>"0"}, {"value"=>"6", "numvotes"=>"0"}, {"value"=>"8", "numvotes"=>"0"}, {"value"=>"10", "numvotes"=>"0"}, {"value"=>"12", "numvotes"=>"5"}, {"value"=>"14", "numvotes"=>"13"}, {"value"=>"16", "numvotes"=>"4"}, {"value"=>"18", "numvotes"=>"2"}, {"value"=>"21 and up", "numvotes"=>"1"}]}]}, {"name"=>"language_dependence", "title"=>"Language Dependence", "totalvotes"=>"43", "results"=>[{"result"=>[{"level"=>"1", "value"=>"No necessary in-game text", "numvotes"=>"33"}, {"level"=>"2", "value"=>"Some necessary text - easily memorized or small crib sheet", "numvotes"=>"4"}, {"level"=>"3", "value"=>"Moderate in-game text - needs crib sheet or paste ups", "numvotes"=>"6"}, {"level"=>"4", "value"=>"Extensive use of text - massive conversion needed to be playable", "numvotes"=>"0"}, {"level"=>"5", "value"=>"Unplayable in another language", "numvotes"=>"0"}]}]}], "playingtime"=>[{"value"=>"240"}], "minage"=>[{"value"=>"14"}], "link"=>[{"type"=>"boardgamecategory", "id"=>"1017", "value"=>"Dice"}, {"type"=>"boardgamecategory", "id"=>"1021", "value"=>"Economic"}, {"type"=>"boardgamecategory", "id"=>"1026", "value"=>"Negotiation"}, {"type"=>"boardgamecategory", "id"=>"1001", "value"=>"Political"}, {"type"=>"boardgamemechanic", "id"=>"2080", "value"=>"Area Control / Area Influence"}, {"type"=>"boardgamemechanic", "id"=>"2012", "value"=>"Auction/Bidding"}, {"type"=>"boardgamemechanic", "id"=>"2072", "value"=>"Dice Rolling"}, {"type"=>"boardgamemechanic", "id"=>"2040", "value"=>"Hand Management"}, {"type"=>"boardgamefamily", "id"=>"10643", "value"=>"Country: Germany"}, {"type"=>"boardgamefamily", "id"=>"91", "value"=>"Valley Games Classic Line"}, {"type"=>"boardgamedesigner", "id"=>"1", "value"=>"Karl-Heinz Schmiel"}, {"type"=>"boardgameartist", "id"=>"12517", "value"=>"Marcus Gschwendtner"}, {"type"=>"boardgamepublisher", "id"=>"133", "value"=>"Hans im Glück Verlags-GmbH"}, {"type"=>"boardgamepublisher", "id"=>"2", "value"=>"Moskito Spiele"}, {"type"=>"boardgamepublisher", "id"=>"5382", "value"=>"Valley Games, Inc."}]}]}
 
 ## Specialized methods
 
 Specialized usage methods are provided as class methods. At this time, only two such methods exist:
 
-## Search boardgame by id
-Returns ONE simple hash, containing most of the game information (see code for details), in which name is the primary name.
-Alternate names are returned as an array with key :alternatenames (without the primay name). Returns nil in case nothing is found
-Example:
-  BggApi.search_boardgame_by_id(53424)
-  {:id=>53424, :name=>"Hexpack", :minplayers=>"0", :maxplayers=>"0", :age=>"0",
-  :description=>"Hexpack is an extrapolation of the piecepack game system ...", :playingtime=>"0",
-  :thumbnail=>"http://cf.geekdo-images.com/images/pic350302_t.jpg", :image=>"http://cf.geekdo-images.com/images/pic350302.jpg",
-  :alternatenames=>[], :yearpublished=>"2008"}
+### Search boardgame by id
+Returns ONE simple hash, containing most of the game information (see code for details), in which `:name` is the primary name.
+Alternate names are returned as an array with key `:alternatenames`, which excludes the primary name. Returns nil if nothing is found.
+
+    BggApi.search_boardgame_by_id(53424)
+    => {:id=>53424, :name=>"Metamorphosis Alpha", :minplayers=>{}, :maxplayers=>{}, :age=>{}, :description=>"From the back cover:<br/><br/>&quot;The Metamorphosis Alpha Campaign Book includes:<br/><br/><br/>     A detailed presentation of the starship Warden with role-playing advice on every level for the new game master and experienced player.<br/>     Complete rules for rolling up and playing robot player characters, android player characters, and pure-strain human player characters.<br/>     Well-detailed rules for the use of radiation, poison, and the generation of mutants of all sorts, as well as a detailed creature section with mutants and aliens.<br/>     The sample city level details how anyone can design his own ship levels. The equipment provided will ake fans of science fiction eager to play the game and join in the fun.<br/><br/><br/>", :playingtime=>{}, :thumbnail=>"http://cf.geekdo-images.com/images/pic534654_t.jpg", :image=>"http://cf.geekdo-images.com/images/pic534654.jpg", :alternatenames=>[], :yearpublished=>{}}
 
 
-##  Search by name
-Returns an array containing the list of all games matching the given name, or nil if none does. This still uses API 1,
-   Example:
-   BggApi.search_by_name('Burgund')
-   {:name=>"The Castles of Burgundy", :type=>"boardgame", :id=>84876}
-   {:name=>"The Castles of Burgundy: New Player Boards", :type=>"boardgame", :id=>110926}
-   {:name=>"Fürsten von Burgund", :type=>"boardgame", :id=>7087}
+###  Search by name
+Returns an array containing the list of all games matching the given name, or nil if none does. This still uses API 1.
+
+    BggApi.search_by_name('Burgund')
+     => [{:name=>"The Castles of Burgundy", :type=>"boardgame", :id=>84876}, {:name=>"The Castles of Burgundy: New Player Boards", :type=>"boardgame", :id=>110926}, {:name=>"The Castles of Burgundy: Player Board  – German board game championship 2013", :type=>"boardgame", :id=>139160}, {:name=>"The Castles of Burgundy: The 2nd Expansion", :type=>"boardgame", :id=>132477}, {:name=>"The Castles of Burgundy: The 4th Expansion", :type=>"boardgame", :id=>150083}, {:name=>"Fürsten von Burgund", :type=>"boardgame", :id=>7087}]
 
 Contributing to bgg-api
------------------------ 
+-----------------------
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it

--- a/lib/bgg-api.rb
+++ b/lib/bgg-api.rb
@@ -39,14 +39,13 @@ class BggApi
     xml = XmlSimple.xml_in(response.body)
     return if xml["total"]=="0"
 
-    xml["item"].each do  |item|
-      result << {
+    xml["item"].map do |item|
+      {
         :name => item["name"][0]["value"],
         :type => item["type"],
         :id   => item["id"].to_i,
       }
     end
-    return result
   end
 
   def self.search_boardgame_by_id(id,type='boardgame')

--- a/lib/bgg-api.rb
+++ b/lib/bgg-api.rb
@@ -3,12 +3,6 @@ require 'xmlsimple'
 
 # http://boardgamegeek.com/wiki/page/BGG_XML_API2#
 
-# because this uses method_missing, the fact that we're including the HTTParty
-# module below into the namespace doesn't seem to help. Likewise with the
-# base_uri method. There's probably some trick to getting this to work, but
-# I haven't yet figured it out and will put it on the list, but later in the
-# process.
-
 class BggApi
   include HTTParty
 
@@ -31,7 +25,7 @@ class BggApi
 
   def self.search_by_name(name,type='boardgame')
 
-    response = HTTParty.get(BASE_URI + '/search', :query=> {:query => name, :type => type})
+    response = get(BASE_URI + '/search', :query=> {:query => name, :type => type})
 
     return if response.code != 200
 
@@ -49,7 +43,7 @@ class BggApi
   end
 
   def self.search_boardgame_by_id(id,type='boardgame')
-    response = HTTParty.get("#{OLD_URI}/boardgame/#{id}")
+    response = get("#{OLD_URI}/boardgame/#{id}")
     return unless response.code == 200
 
     xml = XmlSimple.xml_in(response.body)
@@ -86,7 +80,7 @@ class BggApi
       params ||= {}
 
       url = BASE_URI + '/' + method.to_s
-      response = HTTParty.get(url, :query => params)
+      response = self.class.get(url, :query => params)
 
       if response.code == 200
         xml_data = response.body

--- a/lib/bgg-api.rb
+++ b/lib/bgg-api.rb
@@ -40,7 +40,11 @@ class BggApi
     return if xml["total"]=="0"
 
     xml["item"].each do  |item|
-      result << Hash[:name, item["name"][0]["value"], :type, item["type"],  :id , item["id"].to_i]
+      result << {
+        :name => item["name"][0]["value"],
+        :type => item["type"],
+        :id   => item["id"].to_i,
+      }
     end
     return result
   end
@@ -60,10 +64,25 @@ class BggApi
       end
       xml["boardgame"][0]["name"].slice!(primary_index) unless primary_index.nil?
     end
-    return Hash[:id, id, :name, @primary_name,:minplayers,xml["boardgame"][0]["minplayers"][0],:maxplayers,xml["boardgame"][0]["maxplayers"][0],
-                :age,xml["boardgame"][0]["age"][0], :description, xml["boardgame"][0]["description"][0],:playingtime,xml["boardgame"][0]["playingtime"][0],
-                :thumbnail,xml["boardgame"][0]["thumbnail"][0], :image ,xml["boardgame"][0]["image"][0], :alternatenames,  @alternate_names.sort,
-                :yearpublished,xml["boardgame"][0]["yearpublished"][0] ]
+
+    first_game = xml["boardgame"][0]
+
+    return {
+      :id => id,
+      :name => @primary_name,
+      :minplayers => first_game["minplayers"][0],
+      :maxplayers => first_game["maxplayers"][0],
+
+      :age => first_game["age"][0],
+      :description =>  first_game["description"][0],
+      :playingtime => first_game["playingtime"][0],
+
+      :thumbnail => first_game["thumbnail"][0],
+      :image => first_game["image"][0],
+      :alternatenames =>  @alternate_names.sort,
+
+      :yearpublished => first_game["yearpublished"][0],
+    }
 
   end
 

--- a/spec/bgg_api_spec.rb
+++ b/spec/bgg_api_spec.rb
@@ -1,60 +1,82 @@
 require 'spec_helper'
 
-describe 'BGG Search' do
-  it 'some results come back' do
-    stub_request(:any, 'http://www.boardgamegeek.com/xmlapi2/search').with(:query => {:query => 'Burgund', :type => 'boardgame'}).to_return(:body => File.new('sample_data/search?query=Burgund&type=boardgame'), :status => 200)
+describe BggApi do
+  let(:bgg) { BggApi.new }
 
-    bgg = BggApi.new
-    results = bgg.search({:query => 'Burgund', :type => 'boardgame'})
+  context 'with stubbed responses' do
 
-    results.should_not be_nil
-  end
-end
+    let(:expected_response) { File.open(response_file) }
 
-describe 'BGG Thing' do
-  it 'searches for and returns a thing' do
-    stub_request(:any, 'http://www.boardgamegeek.com/xmlapi2/thing').with(:query => {:id => '84876', :type => 'boardgame'}).to_return(:body => File.new('sample_data/thing?id=84876&type=boardgame'), :status => 200)
+    before do
+      stub_request(:any, request_url)
+        .with(:query => query)
+        .to_return(:body => expected_response, :status => 200)
+    end
 
-    bgg = BggApi.new
-    results = bgg.thing({:id => '84876', :type => 'boardgame'})
+    describe 'BGG Search' do
+      let(:query) { {:query => 'Burgund', :type => 'boardgame'} }
+      let(:request_url) { 'http://www.boardgamegeek.com/xmlapi2/search' }
+      let(:response_file) { 'sample_data/search?query=Burgund&type=boardgame' }
 
-    results.should_not be_nil
-    results['item'][0]['id'].should == '84876'
-  end
-end
+      subject(:results) { bgg.search(query) }
 
-describe 'BGG Collection' do
-  it 'retrieves a collection' do
-    stub_request(:any, 'http://www.boardgamegeek.com/xmlapi2/collection').with(:query => {:own => '1', :username => 'texasjdl', :type => 'boardgame'}).to_return(:body => File.new('sample_data/collection?username=texasjdl&own=1&excludesubtype=boardgameexpansion'), :status => 200)
+      it { should_not be_nil }
+    end
 
-    bgg = BggApi.new
-    results = bgg.collection({:username => 'texasjdl', :own => '1', :type => 'boardgame'})
+    describe 'BGG Thing' do
+      let(:query) { {:id => '84876', :type => 'boardgame'} }
+      let(:request_url) { 'http://www.boardgamegeek.com/xmlapi2/thing' }
+      let(:response_file) { 'sample_data/thing?id=84876&type=boardgame' }
 
-    results.should_not be_nil
-    results['item'][0]['objectid'].should == '421'
-  end
-end
+      subject(:results) { bgg.thing(query) }
 
-describe 'BGG Hot Items' do
-  it 'retrieves the current hot boardgames' do
-    stub_request(:any, 'http://www.boardgamegeek.com/xmlapi2/hot').with(:query => {:type => 'boardgame'}).to_return(:body => File.new('sample_data/hot?type=boardgame'), :status => 200)
+      it { should_not be_nil }
 
-    bgg = BggApi.new
-    results = bgg.hot({:type => 'boardgame'})
+      it 'retrieves the correct id' do
+        results['item'][0]['id'].should == '84876'
+      end
+    end
 
-    results.should_not be_nil
-    results['item'][0]['rank'].should == '1'
-  end
-end
+    describe 'BGG Collection' do
+      let(:query) { {:own => '1', :username => 'texasjdl', :type => 'boardgame'} }
+      let(:request_url) { 'http://www.boardgamegeek.com/xmlapi2/collection' }
+      let(:response_file) { 'sample_data/collection?username=texasjdl&own=1&excludesubtype=boardgameexpansion' }
 
-describe 'BGG Plays' do
-  it 'retrieves the plays for a user' do
-    stub_request(:any, 'http://www.boardgamegeek.com/xmlapi2/plays').with(:query => {:id => '84876', :username => 'texasjdl'}).to_return(:body => File.new('sample_data/plays?username=texasjdl&id=84876'), :status => 200)
+      subject(:results) { bgg.collection(query) }
 
-    bgg = BggApi.new
-    results = bgg.plays({:id => '84876', :username => 'texasjdl'})
+      it { should_not be_nil }
 
-    results.should_not be_nil
-    results['total'].should == '27'
+      it 'retrieves the correct id' do
+        results['item'][0]['objectid'].should == '421'
+      end
+    end
+
+    describe 'BGG Hot Items' do
+      let(:query) { {:type => 'boardgame'} }
+      let(:request_url) { 'http://www.boardgamegeek.com/xmlapi2/hot' }
+      let(:response_file) { 'sample_data/hot?type=boardgame' }
+
+      subject(:results) { bgg.hot(query) }
+
+      it { should_not be_nil }
+
+      it 'retrieves the correct rank' do
+        results['item'][0]['rank'].should == '1'
+      end
+    end
+
+    describe 'BGG Plays' do
+      let(:query) { {:id => '84876', :username => 'texasjdl'} }
+      let(:request_url) { 'http://www.boardgamegeek.com/xmlapi2/plays' }
+      let(:response_file) { 'sample_data/plays?username=texasjdl&id=84876' }
+
+      subject(:results) { bgg.plays(query) }
+
+      it { should_not be_nil }
+
+      it 'retrieves the correct total' do
+        results['total'].should == '27'
+      end
+    end
   end
 end

--- a/spec/bgg_api_spec.rb
+++ b/spec/bgg_api_spec.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 describe BggApi do
   let(:bgg) { BggApi.new }
 
+  describe 'calling undefined methods' do
+    subject { bgg.foo }
+
+    it 'raises an UndefinedMethodError' do
+      expect { subject }.to raise_error(NoMethodError)
+    end
+  end
+
   context 'with stubbed responses' do
 
     let(:expected_response) { File.open(response_file) }

--- a/spec/bgg_user_method_spec.rb
+++ b/spec/bgg_user_method_spec.rb
@@ -44,8 +44,9 @@ describe 'Specialized search by id' do
     result = BggApi.search_boardgame_by_id(325)
     result[:id].should == 325
     result[:name].should == "Catan: Seafarers"
+    result[:alternatenames].size.should == 24
     result[:alternatenames][0].should == "Catan: Navegantes"
-    result[:alternatenames][4].should == "Colonistii din Catan: Navigatorii"
+    result[:alternatenames][4].should == "Catanin uudisasukkaat: Merenkävijät"
   end
 
   it 'should return nil in case of errors' do


### PR DESCRIPTION
Great gem! It was blowing up for me on `BggApi.new` because my IRB was setup to use the awesome_print gem. I found out I could reproduce the issue just by calling a non-existent method:

```
bgg = BggApi.new
bgg.foo
TypeError: exception class/object expected
    from /Users/strathmeyer/.rvm/gems/ruby-2.0.0-p195/bundler/gems/bgg-api-8be15cb6273f/lib/bgg-api.rb:66:in `raise'
    from /Users/strathmeyer/.rvm/gems/ruby-2.0.0-p195/bundler/gems/bgg-api-8be15cb6273f/lib/bgg-api.rb:66:in `call'
```

Basically, it gets a non-200 response, and tries to raise the response code (an integer). You can get the same thing in IRB by running `raise 1`. Commit 929b12d fixes this issue by defining specific methods, instead of using `method_missing`.

Commit 911e8ce fixes a different bug where not all the alternate names are returned.

Along the way, I modernized one of the spec files, fixed up the README, and figured out how to get around calling `HTTParty.` explicitly. 

Merge the whole PR or take the pieces you want!

:dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: :dancer: 
